### PR TITLE
force credential request, and update types with Interlex links

### DIFF
--- a/.datalad/config
+++ b/.datalad/config
@@ -1,2 +1,5 @@
 [datalad "dataset"]
 	id = 2c186076-9acc-11ea-99d2-525400a81410
+[credentials]
+	force-ask = true
+

--- a/DATS.json
+++ b/DATS.json
@@ -42,12 +42,14 @@
   "types": [
     {
       "information": {
-        "value": "MRI"
+        "value": "MRI",
+		"valueIRI": "http://uri.interlex.org/ilx_0779748"
       }
     },
     {
       "information": {
-        "value": "basic demographics"
+        "value": "basic demographics",
+		"valueIRI": "http://uri.interlex.org/ilx_0103016"
       }
     }
   ],


### PR DESCRIPTION
This PR updates `.datalad/config` to require the user to provide credentials every time files are downloaded, and also updates the `types` values with appropriate Interlex links. 